### PR TITLE
Fixed small typo in names_of_classes

### DIFF
--- a/solar_panel_status/api/api.py
+++ b/solar_panel_status/api/api.py
@@ -32,7 +32,7 @@ app.state.model_1 = load_cnn_model()
 def predict(image: bytes=File(...)):
     preprocessed_X = preprocess(BytesIO(image))
     res = app.state.model_1.predict(preprocessed_X)
-    names_of_classes = ['clean','damaged','dirt']
+    names_of_classes = ['clean','damaged','dirty']
 
     return {'prediction': names_of_classes[find_index_of_max_element(res[0].tolist())] }
 


### PR DESCRIPTION
Fixed a small typo within the POST request in the API's names_of_classes variable. 'Dirt' class is now 'Dirty', as expected.